### PR TITLE
Use Claude Sonnet 4 everywhere

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
 # AI API Keys
-OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_KEY=your_openai_api_key # optional
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
 # Optional: File Storage (if using external storage instead of Supabase)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,8 +9,8 @@ Before deploying, ensure you have:
    - Note your project URL and anon key
 
 2. **API Keys**
-   - OpenAI API key from [platform.openai.com](https://platform.openai.com)
-   - Anthropic API key from [console.anthropic.com](https://console.anthropic.com) (optional)
+   - OpenAI API key from [platform.openai.com](https://platform.openai.com) (optional)
+   - Anthropic API key from [console.anthropic.com](https://console.anthropic.com)
 
 3. **Vercel Account**
    - Sign up at [vercel.com](https://vercel.com)
@@ -40,7 +40,7 @@ Before deploying, ensure you have:
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
    
    # AI API Keys
-   OPENAI_API_KEY=sk-your_openai_key_here
+   OPENAI_API_KEY=sk-your_openai_key_here # optional
    ANTHROPIC_API_KEY=sk-ant-your_anthropic_key_here
    ```
 
@@ -107,8 +107,8 @@ Before deploying, ensure you have:
 |----------|-------------|----------|
 | `NEXT_PUBLIC_SUPABASE_URL` | Your Supabase project URL | Yes |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anonymous key | Yes |
-| `OPENAI_API_KEY` | OpenAI API key for GPT models | Yes |
-| `ANTHROPIC_API_KEY` | Anthropic API key for Claude models | Optional |
+| `OPENAI_API_KEY` | OpenAI API key for GPT models | Optional |
+| `ANTHROPIC_API_KEY` | Anthropic API key for Claude Sonnet 4 | Yes |
 
 ## Performance Optimization
 
@@ -138,7 +138,7 @@ Add to `vercel.json`:
 ### 3. AI API Optimization
 
 1. **Configure Rate Limits**:
-   - Monitor API usage in OpenAI/Anthropic dashboards
+   - Monitor API usage in the OpenAI or Anthropic dashboards
    - Implement retry logic for rate limit errors
 
 2. **Optimize Prompts**:

--- a/PROJECT-DOC.md
+++ b/PROJECT-DOC.md
@@ -11,7 +11,7 @@ The application is designed to take a roofing insurance estimate PDF and a roof 
     *   Receives uploaded files.
     *   Creates a job record in the Supabase `jobs` table with `status: 'processing'`.
     *   Asynchronously processes the files:
-        *   Extracts data from both PDFs using an `AIOrchestrator` class (leveraging OpenAI and Anthropic models).
+        *   Extracts data from both PDFs using an `AIOrchestrator` class (defaulting to Anthropic Claude Sonnet 4, with optional OpenAI models).
         *   Analyzes discrepancies between the estimate and roof report.
         *   Generates potential supplement items.
         *   Saves extracted information into the `job_data` table.
@@ -46,7 +46,7 @@ The application is designed to take a roofing insurance estimate PDF and a roof 
 2.  **Accuracy of AI Extractions and Supplement Generation:**
     *   **Issue:** Earlier, there were issues with the AI not correctly extracting multi-line claim numbers and potentially other inaccuracies. The prompt engineering and choice of models are critical here.
     *   **Recent Fixes (Applied):**
-        *   Updated AI models to `gpt-4o` and `claude-3-opus-20240229` (though we discussed `claude-4-sonnet` - this might need re-verification in `database-schema.sql` and AI config).
+        *   Updated AI model to `claude-sonnet-4-20250514`.
         *   Updated prompts in `database-schema.sql` (via `setup-database.sql`) to be more robust, especially for claim number extraction.
         *   Updated the Anthropic SDK version.
     *   **To Address Next:** Rigorous testing is needed to evaluate the accuracy of:
@@ -135,7 +135,7 @@ Update `AIOrchestrator` class to use LogStreamer:
 ```typescript
 // Example integration points:
 async extractEstimateData(jobId: string, pdfContent: string) {
-  logStreamer.logStep(jobId, 'estimate-extraction', 'Analyzing estimate PDF with OpenAI...');
+  logStreamer.logStep(jobId, 'estimate-extraction', 'Analyzing estimate PDF with Claude Sonnet 4...');
   logStreamer.logAIPrompt(jobId, 'estimate-extraction', prompt);
   
   const response = await openai.chat.completions.create({...});

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -2,8 +2,7 @@
 
 ## What We Fixed
 
-1. **Updated to Latest AI Models**:
-   - OpenAI: `gpt-4o` (latest GPT-4 model)
+1. **Updated to Latest AI Model**:
    - Anthropic: `claude-sonnet-4-20250514` (Claude 4 Sonnet)
 
 2. **Fixed API Issues**:
@@ -27,7 +26,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
 
 # AI API Keys
-OPENAI_API_KEY=sk-your_openai_key_here
+OPENAI_API_KEY=sk-your_openai_key_here # optional
 ANTHROPIC_API_KEY=sk-ant-your_anthropic_key_here
 ```
 
@@ -55,10 +54,9 @@ npm run dev
 
 ## What's Different Now
 
-### AI Models Used:
-- **Address/Claim/Carrier/RCV**: OpenAI GPT-4o
-- **Roof Measurements**: Claude 4 Sonnet
-- **Analysis**: Claude 4 Sonnet
+### AI Model Used:
+- **All Steps**: Claude 4 Sonnet
+- You can switch to OpenAI GPT models by setting `OPENAI_API_KEY` and updating `ai_config`
 
 ### Improved Prompts:
 - Better handling of multi-line claim numbers

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ An AI-powered application for analyzing roofing insurance estimates and generati
 ### Prerequisites
 
 1. **Supabase Account**: Sign up at [supabase.com](https://supabase.com)
-2. **OpenAI API Key**: Get from [platform.openai.com](https://platform.openai.com)
-3. **Anthropic API Key** (optional): Get from [console.anthropic.com](https://console.anthropic.com)
+2. **OpenAI API Key** (optional): Get from [platform.openai.com](https://platform.openai.com)
+3. **Anthropic API Key**: Get from [console.anthropic.com](https://console.anthropic.com)
 
 ### Setup Steps
 
@@ -22,7 +22,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
 
 # AI API Keys
-OPENAI_API_KEY=sk-your_openai_key_here
+OPENAI_API_KEY=sk-your_openai_key_here # optional
 ANTHROPIC_API_KEY=sk-ant-your_anthropic_key_here
 ```
 
@@ -43,10 +43,10 @@ DELETE FROM ai_config;
 
 -- Insert updated AI configurations with latest models
 INSERT INTO ai_config (step_name, provider, model, prompt, temperature, max_tokens) VALUES
-('extract_estimate_address', 'openai', 'gpt-4o', 'Extract the property address from this insurance estimate document. Look for the property address, which may be different from the insured''s mailing address. Return only the full property address as a single string.', 0.1, 200),
-('extract_estimate_claim', 'openai', 'gpt-4o', 'Extract the claim number from this insurance estimate document. Look for "Claim Number" or similar labels. The claim number may span multiple lines. Return the complete claim number only, joining any parts with hyphens if split across lines.', 0.1, 100),
-('extract_estimate_carrier', 'openai', 'gpt-4o', 'Extract the insurance carrier/company name from this insurance estimate document. Return only the company name.', 0.1, 100),
-('extract_estimate_rcv', 'openai', 'gpt-4o', 'Extract the total RCV (Replacement Cost Value) amount from this insurance estimate document. Return only the numeric value without currency symbols or commas.', 0.1, 100),
+('extract_estimate_address', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the property address from this insurance estimate document. Look for the property address, which may be different from the insured''s mailing address. Return only the full property address as a single string.', 0.1, 200),
+('extract_estimate_claim', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the claim number from this insurance estimate document. Look for "Claim Number" or similar labels. The claim number may span multiple lines. Return the complete claim number only, joining any parts with hyphens if split across lines.', 0.1, 100),
+('extract_estimate_carrier', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the insurance carrier/company name from this insurance estimate document. Return only the company name.', 0.1, 100),
+('extract_estimate_rcv', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the total RCV (Replacement Cost Value) amount from this insurance estimate document. Return only the numeric value without currency symbols or commas.', 0.1, 100),
 ('extract_roof_measurements', 'anthropic', 'claude-sonnet-4-20250514', 'Extract all roof measurements from this inspection report including: total roof area in squares, eave length, rake length, ridge/hip length, valley length, number of stories, and predominant pitch. Return the values in a structured format with clear labels.', 0.3, 500),
 ('analyze_line_items', 'anthropic', 'claude-sonnet-4-20250514', 'Analyze the provided estimate and roof data to identify missing items or discrepancies. Focus on standard roofing components like drip edge, gutter apron, ice & water barrier, and other items that should be included based on the roof measurements. Return a structured analysis.', 0.5, 1000);
 ```
@@ -83,8 +83,9 @@ Will be correctly extracted as: `1354565-242889-014101`
 - UUID validation to prevent database errors
 
 ### AI Provider Flexibility
-- Supports both OpenAI and Anthropic models
-- Falls back to regex-based extraction when AI is unavailable
+- Defaults to Anthropic Claude Sonnet 4 for all extraction and analysis
+- Supports OpenAI GPT models if `OPENAI_API_KEY` is provided and `ai_config` is updated
+- Falls back to regex-based extraction when no AI provider is available
 - Configurable prompts via database
 
 ## Troubleshooting
@@ -134,7 +135,7 @@ To quickly test with sample data:
 - **Frontend**: Next.js 14 with App Router
 - **Styling**: Tailwind CSS
 - **Database**: Supabase (PostgreSQL)
-- **AI**: OpenAI GPT-4 / Anthropic Claude
+- **AI**: Anthropic Claude Sonnet 4 (default) / optional OpenAI GPT models
 - **PDF Processing**: pdf-parse library
 
 ## Future Enhancements

--- a/setup-database.sql
+++ b/setup-database.sql
@@ -6,10 +6,10 @@ DELETE FROM ai_config;
 
 -- Insert updated AI configurations with latest models
 INSERT INTO ai_config (step_name, provider, model, prompt, temperature, max_tokens) VALUES
-('extract_estimate_address', 'openai', 'gpt-4o', 'Extract the property address from this insurance estimate document. Look for the property address, which may be different from the insured''s mailing address. Return only the full property address as a single string.', 0.1, 200),
-('extract_estimate_claim', 'openai', 'gpt-4o', 'Extract the claim number from this insurance estimate document. Look for "Claim Number" or similar labels. The claim number may span multiple lines. Return the complete claim number only, joining any parts with hyphens if split across lines.', 0.1, 100),
-('extract_estimate_carrier', 'openai', 'gpt-4o', 'Extract the insurance carrier/company name from this insurance estimate document. Return only the company name.', 0.1, 100),
-('extract_estimate_rcv', 'openai', 'gpt-4o', 'Extract the total RCV (Replacement Cost Value) amount from this insurance estimate document. Return only the numeric value without currency symbols or commas.', 0.1, 100),
+('extract_estimate_address', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the property address from this insurance estimate document. Look for the property address, which may be different from the insured''s mailing address. Return only the full property address as a single string.', 0.1, 200),
+('extract_estimate_claim', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the claim number from this insurance estimate document. Look for "Claim Number" or similar labels. The claim number may span multiple lines. Return the complete claim number only, joining any parts with hyphens if split across lines.', 0.1, 100),
+('extract_estimate_carrier', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the insurance carrier/company name from this insurance estimate document. Return only the company name.', 0.1, 100),
+('extract_estimate_rcv', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the total RCV (Replacement Cost Value) amount from this insurance estimate document. Return only the numeric value without currency symbols or commas.', 0.1, 100),
 ('extract_roof_measurements', 'anthropic', 'claude-sonnet-4-20250514', 'Extract all roof measurements from this inspection report including: total roof area in squares, eave length, rake length, ridge/hip length, valley length, number of stories, and predominant pitch. Return the values in a structured format with clear labels.', 0.3, 500),
 ('analyze_line_items', 'anthropic', 'claude-sonnet-4-20250514', 'Analyze the provided estimate and roof data to identify missing items or discrepancies. Focus on standard roofing components like drip edge, gutter apron, ice & water barrier, and other items that should be included based on the roof measurements. Return a structured analysis.', 0.5, 1000);
 

--- a/src/lib/database-schema.sql
+++ b/src/lib/database-schema.sql
@@ -58,10 +58,10 @@ CREATE TABLE ai_config (
 
 -- Insert default AI configurations with latest models
 INSERT INTO ai_config (step_name, provider, model, prompt, temperature, max_tokens) VALUES
-('extract_estimate_address', 'openai', 'gpt-4o', 'Extract the property address from this insurance estimate document. Look for the property address, which may be different from the insured''s mailing address. Return only the full property address as a single string.', 0.1, 200),
-('extract_estimate_claim', 'openai', 'gpt-4o', 'Extract the claim number from this insurance estimate document. Look for "Claim Number" or similar labels. The claim number may span multiple lines. Return the complete claim number only, joining any parts with hyphens if split across lines.', 0.1, 100),
-('extract_estimate_carrier', 'openai', 'gpt-4o', 'Extract the insurance carrier/company name from this insurance estimate document. Return only the company name.', 0.1, 100),
-('extract_estimate_rcv', 'openai', 'gpt-4o', 'Extract the total RCV (Replacement Cost Value) amount from this insurance estimate document. Return only the numeric value without currency symbols or commas.', 0.1, 100),
+('extract_estimate_address', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the property address from this insurance estimate document. Look for the property address, which may be different from the insured''s mailing address. Return only the full property address as a single string.', 0.1, 200),
+('extract_estimate_claim', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the claim number from this insurance estimate document. Look for "Claim Number" or similar labels. The claim number may span multiple lines. Return the complete claim number only, joining any parts with hyphens if split across lines.', 0.1, 100),
+('extract_estimate_carrier', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the insurance carrier/company name from this insurance estimate document. Return only the company name.', 0.1, 100),
+('extract_estimate_rcv', 'anthropic', 'claude-sonnet-4-20250514', 'Extract the total RCV (Replacement Cost Value) amount from this insurance estimate document. Return only the numeric value without currency symbols or commas.', 0.1, 100),
 ('extract_roof_measurements', 'anthropic', 'claude-sonnet-4-20250514', 'Extract all roof measurements from this inspection report including: total roof area in squares, eave length, rake length, ridge/hip length, valley length, number of stories, and predominant pitch. Return the values in a structured format with clear labels.', 0.3, 500),
 ('analyze_line_items', 'anthropic', 'claude-sonnet-4-20250514', 'Analyze the provided estimate and roof data to identify missing items or discrepancies. Focus on standard roofing components like drip edge, gutter apron, ice & water barrier, and other items that should be included based on the roof measurements. Return a structured analysis.', 0.5, 1000);
 


### PR DESCRIPTION
## Summary
- update AI config SQL inserts to use `claude-sonnet-4-20250514`
- update docs and environment examples to prefer Anthropic Claude
- remove references to GPT-4o in quick start and other docs
- keep OpenAI key optional for future use

## Testing
- `npm run lint` *(fails: next not found)*